### PR TITLE
added how to build image from dockerfile in README.md

### DIFF
--- a/DockerfileTravis
+++ b/DockerfileTravis
@@ -1,0 +1,10 @@
+FROM openjdk:8-alpine
+USER root
+RUN apk add --no-cache bash && \
+    adduser -S -u 1001 tutelar
+USER 1001
+EXPOSE 9000
+ENTRYPOINT ["/app/bin/main"]
+CMD []
+# Files from Travis build
+COPY --chown=1001:root ./stage /app

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ A micro-service for authentication.
 #### How to run
 See [Docker images](https://hub.docker.com/r/teamwanari/tutelar/tags)
 
-_TODO_
+docker build .
 
 
 #### Contributing


### PR DESCRIPTION
To build image from dockerfile I have added command in Readme.md. Command can be executed from    parent directory where dockerfile is present.