### PR TITLE
Ldap service api

### DIFF
--- a/src/it/resources/application.conf
+++ b/src/it/resources/application.conf
@@ -1,1 +1,10 @@
 modulesEnabled = "health,basic,email,ldap,github,google,facebook,totp"
+ldap {
+  ldapApi {
+    auth = "basic"
+    basic {
+      username = "testuser"
+      password = "testpass"
+    }
+  }
+}

--- a/src/it/scala/com/wanari/tutelar/providers/userpass/ldap/LdapProviderApiSpec.scala
+++ b/src/it/scala/com/wanari/tutelar/providers/userpass/ldap/LdapProviderApiSpec.scala
@@ -1,0 +1,47 @@
+package com.wanari.tutelar.providers.userpass.ldap
+
+import akka.http.scaladsl.marshallers.sprayjson.SprayJsonSupport._
+import akka.http.scaladsl.model.StatusCodes
+import akka.http.scaladsl.model.headers.BasicHttpCredentials
+import akka.http.scaladsl.server.AuthenticationFailedRejection
+import cats.data.EitherT
+import com.wanari.tutelar.RouteTestBase
+import com.wanari.tutelar.providers.userpass.ldap.LdapService.LdapUserListData
+import com.wanari.tutelar.util.LoggerUtil.LogContext
+import org.mockito.ArgumentMatchersSugar._
+import org.mockito.Mockito._
+
+import scala.concurrent.Future
+
+class LdapProviderApiSpec extends RouteTestBase {
+  import cats.instances.future._
+
+  trait TestScope extends BaseTestScope {
+    import services.configService._
+    implicit lazy val serviceMock = mock[LdapService[Future]]
+    override lazy val route       = new LdapApi().route()
+  }
+  "GET /ldap/users" should {
+    "error without auth" in new TestScope {
+      Get("/ldap/users") ~> route ~> check {
+        rejection shouldBe an[AuthenticationFailedRejection]
+      }
+    }
+    "return the users list" in new TestScope {
+      import LdapApi._
+      import spray.json.DefaultJsonProtocol._
+      import spray.json._
+      val serviceResult: Seq[LdapUserListData] = Seq(
+        LdapUserListData(None, Map("a"         -> JsString("b"), "c" -> JsNumber(1))),
+        LdapUserListData(Some("_id_"), Map("d" -> JsObject("e" -> JsTrue)))
+      )
+      when(serviceMock.listUsers()(any[LogContext])) thenReturn EitherT.rightT(serviceResult)
+
+      val validCredentials = BasicHttpCredentials("testuser", "testpass")
+      Get("/ldap/users") ~> addCredentials(validCredentials) ~> route ~> check {
+        status shouldEqual StatusCodes.OK
+        responseAs[Seq[LdapUserListData]] shouldEqual serviceResult
+      }
+    }
+  }
+}

--- a/src/it/scala/com/wanari/tutelar/providers/userpass/ldap/LdapServiceImplItSpec.scala
+++ b/src/it/scala/com/wanari/tutelar/providers/userpass/ldap/LdapServiceImplItSpec.scala
@@ -4,13 +4,14 @@ import cats.data.EitherT
 import com.wanari.tutelar.core.AuthService
 import com.wanari.tutelar.core.AuthService.TokenData
 import com.wanari.tutelar.core.Errors.AuthenticationFailed
+import com.wanari.tutelar.providers.userpass.ldap.LdapService.LdapUserListData
 import com.wanari.tutelar.util.LoggerUtil.LogContext
 import com.wanari.tutelar.{AwaitUtil, ItTestServices}
 import io.opentracing.noop.NoopTracerFactory
 import org.mockito.ArgumentMatchersSugar.any
 import org.mockito.MockitoSugar
 import org.scalatest.{Matchers, WordSpecLike}
-import spray.json.JsObject
+import spray.json.{JsArray, JsObject, JsString}
 
 import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.Future
@@ -46,6 +47,35 @@ class LdapServiceImplItSpec extends WordSpecLike with Matchers with AwaitUtil wi
     "alice login failed" in {
       await(services.ldapService.login("alice", "bobpw", None).value) shouldEqual Left(
         AuthenticationFailed()
+      )
+    }
+    "list users" in {
+      await(services.ldapService.listUsers().value) shouldEqual Right(
+        Seq(
+          LdapUserListData(
+            None,
+            Map(
+              "givenName" -> JsString("Bob"),
+              "memberOf" -> JsArray(
+                JsString("cn=group1,ou=groups,dc=wanari,dc=com")
+              ),
+              "sn" -> JsString("Dilday"),
+              "cn" -> JsString("bob")
+            )
+          ),
+          LdapUserListData(
+            None,
+            Map(
+              "givenName" -> JsString("Alice"),
+              "memberOf" -> JsArray(
+                JsString("cn=group1,ou=groups,dc=wanari,dc=com"),
+                JsString("cn=group2,ou=groups,dc=wanari,dc=com")
+              ),
+              "sn" -> JsString("Smith"),
+              "cn" -> JsString("alice")
+            )
+          )
+        )
       )
     }
   }

--- a/src/main/resources/application.conf
+++ b/src/main/resources/application.conf
@@ -113,6 +113,7 @@ escher {
   auth-header-name = ${?ESCHER_AUTH_HEADER}
   date-header-name = "X-Escher-Date"
   date-header-name = ${?ESCHER_DATE_HEADER}
+  headers-to-sign = ["host", "X-Escher-Date"]
   algo-prefix = "ESR"
   algo-prefix = ${?ESCHER_ALGO_PREFIX}
   vendor-key = "Escher"
@@ -132,6 +133,16 @@ escher {
       secret-file = ${?ESCHER_SERVICE_HOOK_SECRET_FILE}
       credential-scope = "eu/tutelar/request"
       credential-scope =  ${?ESCHER_SERVICE_HOOK_SCOPE}
+    }
+    {
+      name = "ldap-api"
+      key = "ldap-api-service-key"
+      key = ${?ESCHER_SERVICE_LDAP_API_KEY}
+      secret = "ldap-api-service-secret-key"
+      secret = ${?ESCHER_SERVICE_LDAP_API_SECRET}
+      secret-file = ${?ESCHER_SERVICE_LDAP_API_SECRET_FILE}
+      credential-scope = "eu/tutelar/request"
+      credential-scope =  ${?ESCHER_SERVICE_LDAP_API_SCOPE}
     }
   ]
 }
@@ -223,6 +234,23 @@ ldap {
   userSearchReturnAttributes = ${?LDAP_USER_SEARCH_RETURN_ATTRIBUTES}
   userSearchReturnArrayAttributes = "memberof"
   userSearchReturnArrayAttributes = ${?LDAP_USER_SEARCH_RETURN_ARRAY_ATTRIBUTES}
+
+  ldapApi {
+    // basic, escher
+    auth = "escher"
+    auth = ${?LDAP_API_AUTH}
+    basic {
+      username = ""
+      username = ${?LDAP_API_BASIC_USERNAME}
+      password = ""
+      password = ${?LDAP_API_BASIC_PASSWORD}
+      passwordFile = ${?LDAP_API_BASIC_PASSWORD_FILE}
+    }
+    escher {
+      trustedServices = "ldap-api"
+      trustedServices = ${?LDAP_API_ESCHER_TRUSTED_SERVICES}
+    }
+  }
 }
 
 userpass {

--- a/src/main/scala/com/wanari/tutelar/core/ConfigService.scala
+++ b/src/main/scala/com/wanari/tutelar/core/ConfigService.scala
@@ -5,6 +5,7 @@ import com.wanari.tutelar.core.AmqpService.{AmqpConfig, AmqpQueueConfig}
 import com.wanari.tutelar.core.ExpirationService.ExpirationConfig
 import com.wanari.tutelar.core.HookService.HookConfig
 import com.wanari.tutelar.core.ProviderApi.CallbackConfig
+import com.wanari.tutelar.core.ServiceAuthDirectives.ServiceAuthConfig
 import com.wanari.tutelar.core.TracerService.{JaegerConfig, TracerServiceConfig}
 import com.wanari.tutelar.core.impl.JwtServiceImpl.JwtConfig
 import com.wanari.tutelar.core.impl.database.DatabaseServiceFactory.DatabaseConfig
@@ -39,4 +40,5 @@ trait ConfigService {
   implicit def escherConfig: EscherConfig
   implicit def jaegerConfig: JaegerConfig
   implicit def providerExpirationConfigs: Map[String, ExpirationConfig]
+  implicit def getServiceAuthConfig(path: String): ServiceAuthConfig
 }

--- a/src/main/scala/com/wanari/tutelar/core/ServiceAuthDirectives.scala
+++ b/src/main/scala/com/wanari/tutelar/core/ServiceAuthDirectives.scala
@@ -1,0 +1,32 @@
+package com.wanari.tutelar.core
+
+import akka.http.scaladsl.server.Directive0
+import akka.http.scaladsl.server.Directives.{Authenticator, authenticateBasic, reject}
+import akka.http.scaladsl.server.directives.Credentials.Provided
+import com.emarsys.escher.akka.http.EscherDirectives
+import com.wanari.tutelar.core.ServiceAuthDirectives.{BasicAuthConfig, EscherAuthConfig, ServiceAuthConfig}
+
+trait ServiceAuthDirectives extends EscherDirectives {
+  def getServiceAuthConfig: String => ServiceAuthConfig
+
+  protected def authenticateService(authConfigPath: String): Directive0 = {
+    val authConfig = getServiceAuthConfig(authConfigPath)
+    authConfig match {
+      case BasicAuthConfig(username, password) =>
+        val authenticator: Authenticator[Unit] = {
+          case p @ Provided(u) if u == username && p.verify(password) => Some(())
+          case _                                                      => None
+        }
+        authenticateBasic("", authenticator).map(_ => ())
+      case EscherAuthConfig(trustedServices) =>
+        escherAuthenticate(trustedServices)
+      case _ => reject
+    }
+  }
+}
+
+object ServiceAuthDirectives {
+  sealed trait ServiceAuthConfig
+  case class BasicAuthConfig(username: String, password: String) extends ServiceAuthConfig
+  case class EscherAuthConfig(trustedServices: List[String])     extends ServiceAuthConfig
+}

--- a/src/main/scala/com/wanari/tutelar/providers/userpass/ldap/LdapApi.scala
+++ b/src/main/scala/com/wanari/tutelar/providers/userpass/ldap/LdapApi.scala
@@ -1,9 +1,42 @@
 package com.wanari.tutelar.providers.userpass.ldap
+import akka.http.scaladsl.server.Directives._
+import akka.http.scaladsl.server.Route
+import com.emarsys.escher.akka.http.config.EscherConfig
 import com.wanari.tutelar.core.ProviderApi.CallbackConfig
+import com.wanari.tutelar.core.ServiceAuthDirectives
+import com.wanari.tutelar.core.ServiceAuthDirectives.ServiceAuthConfig
 import com.wanari.tutelar.providers.userpass.UserPassApi
+import com.wanari.tutelar.providers.userpass.ldap.LdapApi._
+import com.wanari.tutelar.providers.userpass.ldap.LdapService.LdapUserListData
+import spray.json.DefaultJsonProtocol._
+import spray.json._
 
 import scala.concurrent.Future
 
-class LdapApi(implicit val service: LdapService[Future], val callbackConfig: CallbackConfig) extends UserPassApi {
+class LdapApi(
+    implicit val service: LdapService[Future],
+    val callbackConfig: CallbackConfig,
+    val getServiceAuthConfig: String => ServiceAuthConfig,
+    val escherConfig: EscherConfig
+) extends UserPassApi
+    with ServiceAuthDirectives {
   override val servicePath: String = "ldap"
+
+  override def route(): Route = {
+    super.route() ~ pathPrefix(servicePath) {
+      path("users") {
+        authenticateService(authConfigPath = "ldap.ldapApi") {
+          get {
+            withTrace(s"List_users_$servicePath") { implicit ctx =>
+              service.listUsers().toComplete
+            }
+          }
+        }
+      }
+    }
+  }
+}
+
+object LdapApi {
+  implicit val formatLdapUSerListData: RootJsonFormat[LdapUserListData] = jsonFormat2(LdapUserListData)
 }

--- a/src/main/scala/com/wanari/tutelar/providers/userpass/ldap/LdapService.scala
+++ b/src/main/scala/com/wanari/tutelar/providers/userpass/ldap/LdapService.scala
@@ -1,5 +1,15 @@
 package com.wanari.tutelar.providers.userpass.ldap
 import com.wanari.tutelar.Initable
+import com.wanari.tutelar.core.Errors.ErrorOr
 import com.wanari.tutelar.providers.userpass.UserPassService
+import com.wanari.tutelar.providers.userpass.ldap.LdapService.LdapUserListData
+import com.wanari.tutelar.util.LoggerUtil.LogContext
+import spray.json.JsValue
 
-trait LdapService[F[_]] extends UserPassService[F] with Initable[F]
+trait LdapService[F[_]] extends UserPassService[F] with Initable[F] {
+  def listUsers()(implicit ctx: LogContext): ErrorOr[F, Seq[LdapUserListData]]
+}
+
+object LdapService {
+  case class LdapUserListData(id: Option[String], ldapData: Map[String, JsValue])
+}

--- a/src/test/resources/application.conf
+++ b/src/test/resources/application.conf
@@ -109,3 +109,37 @@ providerLoginExpiration {
     duration = "1hour"
   }
 }
+
+exampleServiceApiBasic {
+  auth = "basic"
+  basic {
+    username = "u"
+    password = "p"
+  }
+}
+exampleServiceApiEscher {
+  auth = "escher"
+  escher {
+    trustedServices = "service1,service2"
+  }
+}
+
+escher-test {
+  credential-scope = "eu/tutelar/request"
+  auth-header-name = "X-Escher-Auth"
+  date-header-name = "X-Escher-Date"
+  headers-to-sign = ["host", "X-Escher-Date"]
+  algo-prefix = "ESR"
+  vendor-key = "Escher"
+  hostname = "localhost"
+  port = "9000"
+
+  trusted-services = [
+    {
+      name = "test-service"
+      key = "test-key"
+      secret = "test-secret-key"
+      credential-scope = "eu/tutelar/request"
+    }
+  ]
+}

--- a/src/test/scala/com/wanari/tutelar/InitableSpec.scala
+++ b/src/test/scala/com/wanari/tutelar/InitableSpec.scala
@@ -8,7 +8,7 @@ import com.wanari.tutelar.core.impl.JwtServiceImpl
 import com.wanari.tutelar.core.impl.database.DatabaseServiceFactory.DatabaseConfig
 import com.wanari.tutelar.core.impl.database.MongoDatabaseService.MongoConfig
 import com.wanari.tutelar.core.impl.database.PostgresDatabaseService
-import com.wanari.tutelar.core.{AmqpService, ConfigService, ExpirationService}
+import com.wanari.tutelar.core.{AmqpService, ConfigService, ExpirationService, ServiceAuthDirectives}
 import com.wanari.tutelar.providers.oauth2.OAuth2Service
 import com.wanari.tutelar.providers.userpass.PasswordDifficultyCheckerImpl
 import com.wanari.tutelar.providers.userpass.email.{EmailServiceFactory, EmailServiceHttpImpl}
@@ -32,27 +32,28 @@ class InitableSpec extends TestBase {
     }
     implicit val logger = LoggerFactory.getLogger("test")
     implicit val config = new ConfigService {
-      override def getEnabledModules: Seq[String]                                             = Seq("modulename")
-      override def getMongoConfig: MongoConfig                                                = ???
-      override def getDatabaseConfig: DatabaseConfig                                          = ???
-      override def getTracerServiceConfig: TracerServiceConfig                                = ???
-      override def getJwtConfigByName(name: String): JwtServiceImpl.JwtConfig                 = ???
-      override def getCallbackConfig: CallbackConfig                                          = ???
-      override def getHookConfig: HookConfig                                                  = ???
-      override def getAmqpConfig: AmqpService.AmqpConfig                                      = ???
-      override def emailServiceFactoryConfig: EmailServiceFactory.EmailServiceFactoryConfig   = ???
-      override def emailServiceHttpConfig: EmailServiceHttpImpl.EmailServiceHttpConfig        = ???
-      override def totpConfig: TotpServiceImpl.TotpConfig                                     = ???
-      override def getAmqpQueueConfig(name: String): AmqpService.AmqpQueueConfig              = ???
-      override def facebookConfig: OAuth2Service.OAuth2Config                                 = ???
-      override def githubConfig: OAuth2Service.OAuth2Config                                   = ???
-      override def googleConfig: OAuth2Service.OAuth2Config                                   = ???
-      override def ldapConfig: LdapServiceImpl.LdapConfig                                     = ???
-      override def passwordSettings: PasswordDifficultyCheckerImpl.PasswordSettings           = ???
-      override def getPostgresConfig: PostgresDatabaseService.PostgresConfig                  = ???
-      override def escherConfig: EscherConfig                                                 = ???
-      override def jaegerConfig: Configuration                                                = ???
-      override def providerExpirationConfigs: Map[String, ExpirationService.ExpirationConfig] = ???
+      override def getEnabledModules: Seq[String]                                              = Seq("modulename")
+      override def getMongoConfig: MongoConfig                                                 = ???
+      override def getDatabaseConfig: DatabaseConfig                                           = ???
+      override def getTracerServiceConfig: TracerServiceConfig                                 = ???
+      override def getJwtConfigByName(name: String): JwtServiceImpl.JwtConfig                  = ???
+      override def getCallbackConfig: CallbackConfig                                           = ???
+      override def getHookConfig: HookConfig                                                   = ???
+      override def getAmqpConfig: AmqpService.AmqpConfig                                       = ???
+      override def emailServiceFactoryConfig: EmailServiceFactory.EmailServiceFactoryConfig    = ???
+      override def emailServiceHttpConfig: EmailServiceHttpImpl.EmailServiceHttpConfig         = ???
+      override def totpConfig: TotpServiceImpl.TotpConfig                                      = ???
+      override def getAmqpQueueConfig(name: String): AmqpService.AmqpQueueConfig               = ???
+      override def facebookConfig: OAuth2Service.OAuth2Config                                  = ???
+      override def githubConfig: OAuth2Service.OAuth2Config                                    = ???
+      override def googleConfig: OAuth2Service.OAuth2Config                                    = ???
+      override def ldapConfig: LdapServiceImpl.LdapConfig                                      = ???
+      override def passwordSettings: PasswordDifficultyCheckerImpl.PasswordSettings            = ???
+      override def getPostgresConfig: PostgresDatabaseService.PostgresConfig                   = ???
+      override def escherConfig: EscherConfig                                                  = ???
+      override def jaegerConfig: Configuration                                                 = ???
+      override def providerExpirationConfigs: Map[String, ExpirationService.ExpirationConfig]  = ???
+      override def getServiceAuthConfig(path: String): ServiceAuthDirectives.ServiceAuthConfig = ???
     }
   }
   import cats.instances.try_._

--- a/src/test/scala/com/wanari/tutelar/core/ServiceAuthDirectivesSpec.scala
+++ b/src/test/scala/com/wanari/tutelar/core/ServiceAuthDirectivesSpec.scala
@@ -1,0 +1,72 @@
+package com.wanari.tutelar.core
+
+import akka.http.scaladsl.model.headers.BasicHttpCredentials
+import akka.http.scaladsl.model.{HttpRequest, StatusCodes}
+import akka.http.scaladsl.server.AuthenticationFailedRejection
+import akka.http.scaladsl.server.Directives._
+import akka.http.scaladsl.testkit.ScalatestRouteTest
+import com.emarsys.escher.akka.http.config.EscherConfig
+import com.typesafe.config.ConfigFactory
+import com.wanari.tutelar.TestBase
+import com.wanari.tutelar.core.ServiceAuthDirectives.{BasicAuthConfig, EscherAuthConfig}
+import org.scalatest.concurrent.ScalaFutures
+
+import scala.concurrent.duration._
+
+class ServiceAuthDirectivesSpec extends TestBase with ScalatestRouteTest with ScalaFutures {
+  trait BasicTestScope extends ServiceAuthDirectives {
+    override def getServiceAuthConfig: String => ServiceAuthDirectives.ServiceAuthConfig =
+      _ => BasicAuthConfig("user", "pass")
+    override lazy val escherConfig: EscherConfig = null
+
+    val route = path("test") {
+      authenticateService("") {
+        complete("")
+      }
+    }
+  }
+
+  trait EscherTestScope extends ServiceAuthDirectives {
+    override def getServiceAuthConfig: String => ServiceAuthDirectives.ServiceAuthConfig =
+      _ => EscherAuthConfig(List("test-service"))
+    override lazy val escherConfig: EscherConfig = new EscherConfig(ConfigFactory.load().getConfig("escher-test"))
+
+    def signed(r: HttpRequest, intervalMillis: Int = 15): HttpRequest = {
+      signRequest("test-service")(executor, materializer)(r)
+        .futureValue(timeout(1.second), interval(intervalMillis.millis))
+    }
+
+    val route = path("test") {
+      authenticateService("") {
+        complete("")
+      }
+    }
+  }
+
+  "ServiceAuthDirectives" when {
+    "basic auth" should {
+      "reject if wrong credentials" in new BasicTestScope {
+        Get("/test") ~> addCredentials(BasicHttpCredentials("wrong", "pass")) ~> route ~> check {
+          rejection shouldBe an[AuthenticationFailedRejection]
+        }
+      }
+      "ok" in new BasicTestScope {
+        Get("/test") ~> addCredentials(BasicHttpCredentials("user", "pass")) ~> route ~> check {
+          status shouldEqual StatusCodes.OK
+        }
+      }
+    }
+    "escher" should {
+      "reject if wrong credentials" in new EscherTestScope {
+        Get("/test") ~> addCredentials(BasicHttpCredentials("user", "pass")) ~> route ~> check {
+          rejection shouldBe an[AuthenticationFailedRejection]
+        }
+      }
+      "ok" in new EscherTestScope {
+        signed(Get("http://localhost:9000/test")) ~> route ~> check {
+          status shouldEqual StatusCodes.OK
+        }
+      }
+    }
+  }
+}

--- a/src/test/scala/com/wanari/tutelar/core/impl/ConfigServiceSpec.scala
+++ b/src/test/scala/com/wanari/tutelar/core/impl/ConfigServiceSpec.scala
@@ -6,9 +6,10 @@ import com.wanari.tutelar.TestBase
 import com.wanari.tutelar.core.AmqpService.AmqpQueueConfig
 import com.wanari.tutelar.core.ExpirationService.{ExpirationDisabled, ExpirationInactivity, ExpirationLifetime}
 import com.wanari.tutelar.core.HookService.{BasicAuthConfig, HookConfig}
+import com.wanari.tutelar.core.ServiceAuthDirectives
+import com.wanari.tutelar.core.impl.JwtServiceImpl.JwtConfig
 import com.wanari.tutelar.core.impl.database.DatabaseServiceFactory.DatabaseConfig
 import com.wanari.tutelar.core.impl.database.MongoDatabaseService.MongoConfig
-import com.wanari.tutelar.core.impl.JwtServiceImpl.JwtConfig
 import com.wanari.tutelar.providers.oauth2.OAuth2Service.OAuth2Config
 import com.wanari.tutelar.providers.userpass.PasswordDifficultyCheckerImpl.PasswordSettings
 import com.wanari.tutelar.providers.userpass.email.EmailServiceFactory.EmailServiceFactoryConfig
@@ -170,6 +171,18 @@ class ConfigServiceSpec extends TestBase {
     "lifetime" in {
       service.providerExpirationConfigs("cccProvider") shouldBe ExpirationLifetime(
         FiniteDuration(60 * 60, TimeUnit.SECONDS)
+      )
+    }
+  }
+
+  "#getServiceAuthConfig" should {
+    val service = new ConfigServiceImpl {}
+    "basic" in {
+      service.getServiceAuthConfig("exampleServiceApiBasic") shouldBe ServiceAuthDirectives.BasicAuthConfig("u", "p")
+    }
+    "escher" in {
+      service.getServiceAuthConfig("exampleServiceApiEscher") shouldBe ServiceAuthDirectives.EscherAuthConfig(
+        List("service1", "service2")
       )
     }
   }

--- a/swagger.yml
+++ b/swagger.yml
@@ -265,6 +265,42 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/TokenData'
+  /ldap/users:
+    get:
+      description: List all LDAP user
+      responses:
+        '200':
+          description: LDAP users with data from LDAP and tutelar id if exists
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  type: object
+                  properties:
+                    id:
+                      type: string
+                    ldapData:
+                      type: object
+                  required:
+                    - ldapData
+              examples:
+                '0':
+                  value:
+                    - id: '93571113-42d5-4e88-b347-95dafda4b6eb'
+                      ldapData:
+                        cn: bob
+                        givenName: Bob
+                        memberOf:
+                          - 'cn=group1,ou=groups,dc=wanari,dc=com'
+                        sn: Dilday
+                    - ldapData:
+                        cn: alice
+                        givenName: Alice
+                        memberOf:
+                          - 'cn=group1,ou=groups,dc=wanari,dc=com'
+                          - 'cn=group2,ou=groups,dc=wanari,dc=com'
+                        sn: Smith
   /github/login:
     get:
       description: Login with GitHub


### PR DESCRIPTION
Add new api `/ldap/user` to list users from ldap.

Authenticate with basic/escher.

TODO: add user id (from tutelar db) to response

Example:
`curl -u uuu:ppp localhost:9000/ldap/users | jq`
```
[
  {
    "ldapData": {
      "cn": "bob",
      "givenName": "Bob",
      "memberOf": [
        "cn=group1,ou=groups,dc=wanari,dc=com"
      ],
      "sn": "Dilday"
    }
  },
  {
    "ldapData": {
      "cn": "alice",
      "givenName": "Alice",
      "memberOf": [
        "cn=group1,ou=groups,dc=wanari,dc=com",
        "cn=group2,ou=groups,dc=wanari,dc=com"
      ],
      "sn": "Smith"
    }
  }
]
```